### PR TITLE
chore: add scope to pr-title test

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -36,12 +36,13 @@ version-resolver:
   minor:
     labels:
       - "enhancement"
-      - "fix"
+      - "feature"
       - "minor"
   patch:
     labels:
       - "documentation"
       - "maintenance"
+      - "fix"
       - "patch"
   default: patch
 autolabeler:

--- a/.github/workflows/test-pr-title.yaml
+++ b/.github/workflows/test-pr-title.yaml
@@ -30,6 +30,7 @@ jobs:
       scopes: |
         ci
         docs
+        deps
       requireScope: false
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
the deps scope needs to be added to pr-title test to allow depeendabot PRs since I prefix them with chore(deps) from the dependabot config.

also update release-drafter

- [x] `feature` label is a minor semver change
- [x] `fix` label is a patch semver change