### PR TITLE
feat: Add attestation option to release-image

### DIFF
--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -60,11 +60,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           provenance: false
           sbom: false
-      # Generate a build attestation and push it to sigstore
       - name: Generate artifact attestation
         if: ${{ inputs.create-attestation }}
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-name: ${{ env.IMAGE_REGISTRY }}/${{ inputs.image-name}}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -12,6 +12,10 @@ on:
       short-tag:
         required: true
         type: string
+      create-attestation:
+        required: false
+        type: boolean
+        default: false
     secrets:
       github-token:
         required: true
@@ -44,6 +48,7 @@ jobs:
       - name: Push Docker Image
         if: ${{ success() }}
         uses: docker/build-push-action@67a2d409c0a876cbe6b11854e3e25193efe4e62d
+        id: push
         with:
           context: .
           file: ./Dockerfile
@@ -55,3 +60,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           provenance: false
           sbom: false
+      # Generate a build attestation and push it to sigstore
+      - name: Generate artifact attestation
+        if: ${{ inputs.create-attestation }}
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -29,6 +29,7 @@ jobs:
       image-name: github/ospo-reusable-workflows
       full-tag: ${{ needs.release.outputs.full-tag }}
       short-tag: ${{ needs.release.outputs.short-tag }}
+      create-attestation: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
       image-registry: ghcr.io


### PR DESCRIPTION
This change adds an optional input `create-attestion` which will push a cryptographically strong build attestation to GitHub's sigstore instance, to enable consumers to verify the built container's contents matched the build.

For more on attestations see : https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds