### PR TITLE
fix: permissions for attestations image release step

### DIFF
--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -31,6 +31,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     env:
       IMAGE_REGISTRY: ${{ secrets.image-registry }}
       IMAGE_REGISTRY_USERNAME: ${{ secrets.image-registry-username }}


### PR DESCRIPTION
Believe this will fix the following error:

```
Error: Failed to get ID token: Error message: Unable to get 
ACTIONS_ID_TOKEN_REQUEST_URL env variable
```