### PR TITLE
ci: reduce permissions on auto-labeler and set to not release

### DIFF
--- a/.github/workflows/auto-labeler.yaml
+++ b/.github/workflows/auto-labeler.yaml
@@ -14,7 +14,6 @@ permissions:
 jobs:
   main:
     permissions:
-      contents: write
       pull-requests: write
     name: Auto label pull requests
     runs-on: ubuntu-latest
@@ -24,3 +23,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.github-token }}
         with:
           config-name: ${{ inputs.config-name }}
+          disable-releaser: true

--- a/.github/workflows/test-auto-labeler.yaml
+++ b/.github/workflows/test-auto-labeler.yaml
@@ -9,7 +9,6 @@ permissions:
 jobs:
   auto_labeler:
     permissions:
-      contents: write
       pull-requests: write
     uses: ./.github/workflows/auto-labeler.yaml
     with:

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -26,7 +26,7 @@ jobs:
       attestations: write
     uses: ./.github/workflows/release-image.yaml
     with:
-      image-name: github/ospo-reusable-workflows
+      image-name: ${{ github.repository }}
       full-tag: ${{ needs.release.outputs.full-tag }}
       short-tag: ${{ needs.release.outputs.short-tag }}
       create-attestation: true


### PR DESCRIPTION
We were seeing random draft releases after a release occurred. I realized the auto-labeler workflow (also using draft-release action) was still doing a draft release.  This was the culprit.  By adding `disable-releaser: true`, we prevent this.  Since this workflow no longer needs to create a release we can remove the `contents: write` permissions also.

- [x] change image-name from hard-coded to github.repository in test-release