### PR TITLE
ci: turn off image attestations temporarily until fix in place

### DIFF
--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -29,7 +29,6 @@ jobs:
       image-name: ${{ github.repository }}
       full-tag: ${{ needs.release.outputs.full-tag }}
       short-tag: ${{ needs.release.outputs.short-tag }}
-      create-attestation: true
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
       image-registry: ghcr.io


### PR DESCRIPTION
For some reason attestations and the way they interact with the image release a new image isn't released and new tags are going onto old images