### PR TITLE
ci: remove attestations temporarily

### DIFF
--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -12,10 +12,6 @@ on:
       short-tag:
         required: true
         type: string
-      create-attestation:
-        required: false
-        type: boolean
-        default: false
     secrets:
       github-token:
         required: true
@@ -62,10 +58,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           provenance: false
           sbom: false
-      - name: Generate artifact attestation
-        if: ${{ inputs.create-attestation }}
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ${{ env.IMAGE_REGISTRY }}/${{ inputs.image-name}}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true


### PR DESCRIPTION
Unfortunately attestations are causing confusion in the image registry.  Need to resolve that before putting it back.