### PR TITLE
feat: ensure contents of container image changes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,27 +1,32 @@
 # Common
-*.md
+
+_.md
 docker-compose.yml
-Dockerfile*
-.env*
+Dockerfile_
+.env\*
 Makefile
 
 # Logs
+
 logs
-*.log
+\*.log
 
 # IDE's
+
 .vscode/
 .idea/
 
 # Dependency directories
+
 node_modules/
 .venv/
 
 ## Cache directories
+
 .parcel-cache
 
 # git
+
 .git
 .gitattributes
 .gitignore
-.github/

--- a/.github/workflows/test-auto-labeler.yaml
+++ b/.github/workflows/test-auto-labeler.yaml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   auto_labeler:
     permissions:
+      contents: read
       pull-requests: write
     uses: ./.github/workflows/auto-labeler.yaml
     with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,9 @@
 FROM alpine
-CMD ["echo", "Hello World!!"]
+
+WORKDIR /app
+
+# copy all files from repo to ensure all changes are included
+# which will ensure a new image digest is generated
+COPY . .
+
+CMD ["cat", "README.md"]

--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ This is a placeholder repo for multiple GitHub Actions we use in open source pro
 > - [labeler.yml](.github/labeler.yml)
 > - [release-drafter.yaml](.github/release-drafter.yaml)
 
-> [!WARNING]  
-> The container image generated in this repo is a placeholder, it contains no content. It uses [alpine:latest and says "Hello World"](https://github.com/github/ospo-reusable-workflows/blob/main/Dockerfile). The image creation option is for GitHub Actions who need it because their Action is not written in JavaScript/Typescript and they want to track downloads/usage.
+> [!NOTE]
+> The container image generated in this repo is a placeholder, it contains the files of this repository to ensure it shows "change" and a new container image digest is generated. This allows us to see tagging of the new container image is working and newly generated attestation is related to a new SHA/digest in the [packages view](https://github.com/github/ospo-reusable-workflows/pkgs/container/ospo-reusable-workflows).

--- a/docs/auto-labeler.md
+++ b/docs/auto-labeler.md
@@ -5,6 +5,7 @@
 ```yaml
 - uses: github/ospo-reusable-workflows/.github/workflows/auto-labeler.yml@main
   permissions:
+    contents: read
     pull-requests: write
   with:
     # The name of the configuration file to use, default is release-drafter.yml


### PR DESCRIPTION
I got confused when the release tagging was being applied to the same release package (container image).  This was because the container image was not changing.

With this change, we put the contents of the repo into the container image, ensuring there is change and a new image and digest is created.  This will also cause new attestation to be created.

- [x] remove .github folder from .dockerignore to ensure the folder is put into the container image
- [x] update README explaining what the image contents are and why