### PR TITLE
feat: major version updater

### DIFF
--- a/.github/workflows/major-version-updater.yaml
+++ b/.github/workflows/major-version-updater.yaml
@@ -1,0 +1,33 @@
+---
+name: "Major Version Updater"
+on:
+  workflow_call:
+    inputs:
+      tag_name:
+        required: true
+        type: string
+permissions:
+  contents: read
+jobs:
+  major_version_updater:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          fetch-tags: true
+          ref: ${{ inputs.tag_name }}
+      - name: version
+        id: version
+        env:
+          TAG_NAME: ${{ inputs.tag_name }}
+        run: |
+          tag=${TAG_NAME/refs\/tags\//}
+          version=${tag#v}
+          major=${version%%.*}
+          { echo "tag=${tag}"; echo "version=${version}"; echo "major=${major}"; } >> "$GITHUB_OUTPUT"
+      - name: force update major tag
+        run: |
+          git tag -f v${{ steps.version.outputs.major }} ${{ steps.version.outputs.tag }}
+          git push -f origin v${{ steps.version.outputs.major }}

--- a/.github/workflows/test-major-version-updater.yaml
+++ b/.github/workflows/test-major-version-updater.yaml
@@ -1,0 +1,19 @@
+---
+name: "Test Major Version Updater"
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      TAG_NAME:
+        description: "Tag name that the major tag will point to (e.g. v1.2.3)"
+        required: true
+permissions:
+  contents: read
+jobs:
+  labeler:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/major-version-updater.yaml
+    with:
+      tag_name: ${{ github.event.inputs.TAG_NAME || github.ref}}


### PR DESCRIPTION
Updates the major version to point to the latest published tag with the same major tag

Example:

v2.2.0 exists
v2 is currently pointed to v2.2.0

release happens

v2.3.0 is created
this action will point v2 at the new v2.3.0


I did take a look at https://github.com/actions/publish-action but it has a [known permission issue](https://github.com/orgs/community/discussions/116660)