### PR TITLE
fix: update readme about dependabot labels

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,7 @@ updates:
       timezone: 'America/Chicago'
     commit-message:
       prefix: "chore(deps)"
+    labels: ["github_actions", "dependencies"]
     groups:
       dependencies:
         applies-to: version-updates

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ This is a placeholder repo for multiple GitHub Actions we use in open source pro
 >
 > [Workflows](.github/workflows)
 
+> [!CAUTION]
+> In our default `release-drafter.yaml` file and hardcoded in our `release.yaml` reusable workflow, we use the labels `major`, `minor`, and `patch` to determine the type of release to create. Unfortunately, Dependabot uses these same labels, by default, on its PRs to indicate the type of version update. This can cause unintended releases to be created when Dependabot PRs are merged.
+> The "fix" is to include `labels: ["package-name", "dependencies"]` in your `dependabot.yaml` configuration file to ensure Dependabot PRs are labeled correctly and do not use the `major`, `minor`, or `patch` labels.
+> You can see an example of this in the [dependabot.yaml](.github/dependabot.yaml) file in this repository.
+
 > [!TIP]
 > You can reuse the following files in this repository in your own as they are used by the reusable workflows:
 >


### PR DESCRIPTION
Based on [Dependabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#labels--) we can specify the labels applied. Previously Dependabot was applying `major`, `minor', or `patch` labels based on the version of dependency updates. This was causing conflicts with our auto releasing. If those labels were present they were being applied to our releases. This is not what we want. We are changing the Dependabot config to just note the package type (i.e., go, github_actions, etc) and `dependencies`, in case we ever need to filter in the UI.

Updated README with a CAUTION flag about this.